### PR TITLE
Fix ReferenceError to enable error logging

### DIFF
--- a/join.js
+++ b/join.js
@@ -1256,9 +1256,7 @@ var refreshDevices = function(callback){
 getToken();
 chrome.gcm.register(["596310809542","737484412860"],function(registrationId) {
 	if (registrationId == null || registrationId == "") {
-		if (callback != null) {
-			console.log("Error getting key: " + chrome.runtime.lastError);
-		}
+		console.log("Error getting key: " + chrome.runtime.lastError);
 	} else {
 		console.log("Got key: " + registrationId);
 		localStorage.regIdLocal = registrationId;


### PR DESCRIPTION
Fix ReferenceError on `callback` which prohibits the GCM register error to be outputted correctly