### PR TITLE
Fix issue #43 (Google Chrome is using your microphone bug)

### DIFF
--- a/js/gcm.js
+++ b/js/gcm.js
@@ -753,13 +753,13 @@ var GCMNotification = function(notification, senderId){
 				chromeNotification.notify();
 			}
 			notifications.push(not);
-			if(not.replyId){
+			if(not.replyId && back.getVoiceEnabled()){
 				back.UtilsVoice.isMicAvailable()
 				.then(()=>true)
 				.catch(()=>false)
 				.then(micAvailable=>{
 					if(micAvailable){
-						if(back.getVoiceEnabled() && back.getVoiceContinuous() && back.getVoiceWakeup()){						
+						if(back.getVoiceContinuous() && back.getVoiceWakeup()){						
 							UtilsObject.doOnce("replywithvoicee",()=>showNotification("Reply With Voice",showNotification("Reply With Voice",`Say "${back.getVoiceWakeup()} reply with hello" for example to reply to this notification with your voice`,30000)));	
 						}
 						if(!back.getVoiceContinuous()){


### PR DESCRIPTION
By checking the voice control config option before testing whether a mic is accessible, we can avoid the Chrome tray icon showing up under OS X and Linux when voice control is disabled.