### PR TITLE
join.js: in createPushClipboardWindow, subtract width rather than 230

### DIFF
--- a/join.js
+++ b/join.js
@@ -118,7 +118,7 @@ var createPushClipboardWindow = function(tab,params,paramsIfClosed,closeAfterCom
         if(!height){
             height = 606;
         }
-		chrome.windows.create({ url: url, type: 'popup' , left: screen.width - 230, top: Math.round((screen.height / 2) - (height /2)), width : width, height: height},function(clipboardWindow){
+		chrome.windows.create({ url: url, type: 'popup' , left: screen.width - width, top: Math.round((screen.height / 2) - (height /2)), width : width, height: height},function(clipboardWindow){
 				popupWindowClipboard = clipboardWindow;
 				popupWindowClipboardId = clipboardWindow.id;
 		});


### PR DESCRIPTION
Fixes #120.  If you widen the popout window, then it would refuse to open.
This fixes that issue.  The same ` - width` idiom is used in several other places.