### PR TITLE
global_styles.css: reduce min-height to 500px

### DIFF
--- a/global_styles.css
+++ b/global_styles.css
@@ -18,7 +18,7 @@ body {
 	-webkit-font-smoothing: antialiased; /*For Mac OS / OSX*/
 	overflow: hidden;	
 	height: calc(var(--vh, 1vh) * 100);
-	min-height: 600px;
+	min-height: 500px;
 }
 svg{
 	fill: var(--theme-accent-color-lowlight);


### PR DESCRIPTION
With 600px, the attached window you get when clicking on the Join extension icon required a scroll bar, making the tab buttons not visible by default.  500px works for me, but I don't know how to choose a value that will work universally.